### PR TITLE
#160 の修正

### DIFF
--- a/Sources/MainProgram.ts
+++ b/Sources/MainProgram.ts
@@ -19,7 +19,7 @@ import { InversionKind, GameGraphicsForApplet } from "./GameGraphicsForApplet";
 import { Option, MainLayer, MapchipLayer } from "./MasaoOption";
 import { GameMouse } from "./GameMouse";
 import { GameKey } from "./GameKey";
-import { GameSoundForApplet } from "./GameSoundForApplet";
+import { GameSoundBase } from "./GameSoundForApplet";
 import { TagDataBase } from "./TagDataBase";
 import { MasaoConstruction } from "./MasaoConstruction";
 
@@ -35,7 +35,7 @@ type Parts = {
  * @param gamegraphics {GameGraphicsForApplet}
  * @param gamemouse {GameMouse}
  * @param gamekey {GameKey}
- * @param gamesound {GameSoundForApplet}
+ * @param gamesound {GameSoundBase<any>}
  * @param tagdatabase {TagDataBase}
  * @constructor
  */
@@ -329,7 +329,7 @@ class MainProgram {
 	gg: GameGraphicsForApplet;
 	gm: GameMouse;
 	gk: GameKey;
-	gs: GameSoundForApplet;
+	gs: GameSoundBase<any>;
 	tdb: TagDataBase;
 	spot_img: ImageBuff;
 	spot_g: Graphics;
@@ -348,7 +348,7 @@ class MainProgram {
 		gamegraphics: GameGraphicsForApplet,
 		gamemouse: GameMouse,
 		gamekey: GameKey,
-		gamesound: GameSoundForApplet,
+		gamesound: GameSoundBase<any>,
 		tagdatabase: TagDataBase
 	) {
 		// マップの幅と高さ（ブロック単位）。将来はここを変数にする。

--- a/Sources/MasaoConstruction.ts
+++ b/Sources/MasaoConstruction.ts
@@ -1,7 +1,7 @@
 import { GameGraphicsForApplet } from "./GameGraphicsForApplet";
 import { GameKey, GameKey_keyPressed, GameKey_keyReleased } from "./GameKey";
 import { GameMouse, GameMouse_mousePressed, GameMouse_mouseReleased } from "./GameMouse";
-import { GameSoundForApplet } from "./GameSoundForApplet";
+import { GameSoundBase, GameSoundForApplet } from "./GameSoundForApplet";
 import { AudioClip, Game, rightShiftIgnoreSign, waitFor, rounddown } from "./GlobalFunctions";
 import { Color, Font, ImageBuff, Graphics } from "./ImageBuff";
 import { MainProgram } from "./MainProgram";
@@ -63,7 +63,7 @@ class MasaoConstruction {
 	gg: GameGraphicsForApplet;
 	gm: GameMouse;
 	gk: GameKey;
-	gs: GameSoundForApplet;
+	gs: GameSoundBase<any>;
 	mp: MainProgram;
 	mph_title_lock_f: boolean;
 	mph_start_game_f: boolean;


### PR DESCRIPTION
close #160 

オーディオ制御クラスの共通部分を抽象クラス GameSoundBase に抜き出し、 s_data, bgm の型を補正。
各文の実行順を適切な順序に修正。
GameSoundForApplet が GameSoundWebAudio の基底クラスではなくなったので、影響を受ける部分を一緒に修正。