### PR TITLE
システム色変更機能実装

### DIFF
--- a/Sources/IdouGamen.ts
+++ b/Sources/IdouGamen.ts
@@ -412,7 +412,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2),
 						rounddown(this.gg.di.height / 2),
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 210;
 				}
@@ -437,7 +437,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2),
 						rounddown(this.gg.di.height / 2),
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 210;
 				}
@@ -591,7 +591,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2) + 80,
 						rounddown(this.gg.di.height / 2) + 31,
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 520;
 				}
@@ -779,7 +779,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2),
 						rounddown(this.gg.di.height / 2),
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 200;
 					this.co_j.pt = 1010;
@@ -796,7 +796,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2),
 						rounddown(this.gg.di.height / 2),
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 300;
 					this.co_j.pt = 1010;
@@ -814,7 +814,7 @@ class IdouGamen {
 							rounddown((this.gg.di.width - 272) / 2),
 							rounddown(this.gg.di.height / 2),
 							216,
-							Color.cyan
+							this.mp.gamecolor_message_name
 						);
 						this.km.mode = 400;
 					} else {
@@ -826,7 +826,7 @@ class IdouGamen {
 							rounddown((this.gg.di.width - 272) / 2),
 							rounddown(this.gg.di.height / 2),
 							216,
-							Color.cyan
+							this.mp.gamecolor_message_name
 						);
 						this.km.mode = 210;
 					}
@@ -844,7 +844,7 @@ class IdouGamen {
 						rounddown((this.gg.di.width - 272) / 2),
 						rounddown(this.gg.di.height / 2),
 						272,
-						Color.cyan
+						this.mp.gamecolor_message_name
 					);
 					this.km.mode = 500;
 					this.co_j.pt = 1010;

--- a/Sources/ImageBuff.ts
+++ b/Sources/ImageBuff.ts
@@ -801,6 +801,14 @@ class Color {
 		return this.b;
 	}
 
+	/**
+	 * アルファ値を取得する
+	 * @returns {number|*}
+	 */
+	getAlpha() {
+		return this.a;
+	}
+
 	static white = new Color(255, 255, 255);
 	static WHITE = Color.white;
 	static lightGray = new Color(192, 192, 192);

--- a/Sources/KeyboardMenu.ts
+++ b/Sources/KeyboardMenu.ts
@@ -421,7 +421,7 @@ class KeyboardMenu {
 				case 100:
 					// active
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 30 + this.item_kazu[i] * 14);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.message[i], this.x[i] + 24, this.y[i] + 6 + 12);
 					if (this.item_kazu[i] >= 1) {
 						for (let j = 0; j <= this.item_kazu[i] - 1; j++) {
@@ -437,24 +437,30 @@ class KeyboardMenu {
 					}
 					break;
 				case 200:
-					this.hg.setColor(Color.white);
-					this.hg.fillRect(12, 12, 128, 58);
-					this.hg.setColor(Color.black);
+					this.hg.setColor(this.ap.mp.gamecolor_message_border);
+					this.hg.fillRect(12, 12, 128, 2);
+					this.hg.fillRect(12, 12 + 2, 2, 54);
+					this.hg.fillRect(12 + 2 + 124, 12 + 2, 2, 54);
+					this.hg.fillRect(12, 12 + 2 + 54, 128, 2);
+					this.hg.setColor(this.ap.mp.gamecolor_message_back);
 					this.hg.fillRect(14, 14, 124, 54);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[14][0], 18, 30);
 					if (this.item_int[14][0] <= 0 || this.item_int[14][2] <= 0) {
 						this.hg.setColor(Color.red);
 						this.hg.drawString("戦闘不能", 82, 30);
 					}
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("HP	" + this.item_int[14][0] + " / " + this.item_int[14][1], 18, 48);
 					this.hg.drawString("PP	" + this.item_int[14][2] + " / " + this.item_int[14][3], 18, 62);
 					break;
 				case 210:
-					this.hg.setColor(Color.white);
-					this.hg.fillRect(160, 12, 128, 58);
-					this.hg.setColor(Color.black);
+					this.hg.setColor(this.ap.mp.gamecolor_message_border);
+					this.hg.fillRect(160, 12, 128, 2);
+					this.hg.fillRect(160, 12 + 2, 2, 54);
+					this.hg.fillRect(160 + 2 + 124, 12 + 2, 2, 54);
+					this.hg.fillRect(160, 12 + 2 + 54, 128, 2);
+					this.hg.setColor(this.ap.mp.gamecolor_message_back);
 					this.hg.fillRect(162, 14, 124, 54);
 					this.hg.setColor(Color.green);
 					this.hg.drawString(this.item[15][0], 166, 30);
@@ -462,29 +468,32 @@ class KeyboardMenu {
 						this.hg.setColor(Color.red);
 						this.hg.drawString("戦闘不能", 230, 30);
 					}
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("HP	" + this.item_int[15][0] + " / " + this.item_int[15][1], 166, 48);
 					this.hg.drawString("PP	" + this.item_int[15][2] + " / " + this.item_int[15][3], 166, 62);
 					break;
 				case 220:
-					this.hg.setColor(Color.white);
-					this.hg.fillRect(372, 12, 128, 58);
-					this.hg.setColor(Color.black);
+					this.hg.setColor(this.ap.mp.gamecolor_message_border);
+					this.hg.fillRect(372, 12, 128, 2);
+					this.hg.fillRect(372, 12 + 2, 2, 54);
+					this.hg.fillRect(372 + 2 + 124, 12 + 2, 2, 54);
+					this.hg.fillRect(372, 12 + 2 + 54, 128, 2);
+					this.hg.setColor(this.ap.mp.gamecolor_message_back);
 					this.hg.fillRect(374, 14, 124, 54);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[15][0], 378, 30);
 					if (this.item_int[15][0] <= 0 || this.item_int[15][2] <= 0) {
 						this.hg.setColor(Color.red);
 						this.hg.drawString("戦闘不能", 442, 30);
 					}
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("HP	" + this.item_int[15][0] + " / " + this.item_int[15][1], 378, 48);
 					this.hg.drawString("PP	" + this.item_int[15][2] + " / " + this.item_int[15][3], 378, 62);
 					break;
 				case 300:
 					// activeIchigyou
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 40);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
 					if (this.c_fc <= 3) {
 						this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 6 + 14 + 0 + 2, 201, 0);
@@ -495,7 +504,7 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 58);
 					this.hg.setColor(this.item_color[i]);
 					this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 12);
 					if (this.c_fc <= 3) {
 						this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 6 + 18 + 14 + 2, 71, 0);
@@ -506,11 +515,11 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 66 + (this.item_kazu[i] - 3) * 14 + 14);
 					this.hg.setColor(Color.magenta);
 					this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 12);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[i][2], this.x[i] + 6, this.y[i] + 6 + 36 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					for (let j = 0; j <= this.item_kazu[3] - 4; j++) {
 						this.hg.drawString(this.item[3][j + 3], this.x[3] + 6, this.y[3] + 6 + 54 + j * 14 + 12);
 					}
@@ -526,15 +535,15 @@ class KeyboardMenu {
 				case 321:
 					// activeYongyou2
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 108);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 12);
 					this.hg.setColor(Color.magenta);
 					this.hg.drawString(this.item[i][2], this.x[i] + 6, this.y[i] + 6 + 36 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][3], this.x[i] + 6, this.y[i] + 6 + 54 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][4], this.x[i] + 6, this.y[i] + 6 + 54 + 14 + 12);
 					if (this.c_fc <= 3) {
 						this.gg.drawPT(
@@ -550,7 +559,7 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 30 + (this.item_kazu[i] + 1) * 14);
 					this.hg.setColor(this.item_color[i]);
 					this.hg.drawString(this.message[i], this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					if (this.item_kazu[i] >= 1) {
 						for (let j = 0; j <= this.item_kazu[i] - 1; j++) {
 							this.hg.drawString(this.item[i][j], this.x[i] + 6, this.y[i] + 6 + 18 + j * 14 + 12);
@@ -581,7 +590,7 @@ class KeyboardMenu {
 						break;
 					}
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 26);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
 					this.item_int[i][0] -= 1;
 					if (this.item_int[i][0] <= 0) {
@@ -594,7 +603,7 @@ class KeyboardMenu {
 						this.drawWindowbox(this.x[i], this.y[i], this.width[i], 44);
 						this.hg.setColor(this.item_color[i]);
 						this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
-						this.hg.setColor(Color.white);
+						this.hg.setColor(this.ap.mp.gamecolor_message_text);
 						this.hg.drawString(this.item[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 12);
 					} else if (this.item_int[i][0] == 100) {
 						this.item_int[i][0] = 55;
@@ -602,7 +611,7 @@ class KeyboardMenu {
 						this.drawWindowbox(this.x[i], this.y[i], this.width[i], 44);
 						this.hg.setColor(this.item_color[i]);
 						this.hg.drawString(this.item[i][0], this.x[i] + 6, this.y[i] + 6 + 12);
-						this.hg.setColor(Color.white);
+						this.hg.setColor(this.ap.mp.gamecolor_message_text);
 						this.hg.drawString(this.item[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 12);
 						this.item_int[i][0] -= 1;
 						if (this.item_int[i][0] <= 0) {
@@ -615,7 +624,7 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 128);
 					this.hg.setColor(Color.yellow);
 					this.hg.drawString(this.name_crys + "のステータス", this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(
 						"HP	" + this.item_int[14][0] + " / " + this.item_int[14][1],
 						this.x[i] + 6,
@@ -640,9 +649,9 @@ class KeyboardMenu {
 						this.item_int[i][2],
 						0
 					);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[i][0], this.x[i] + 12, this.y[i] + 64 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("これからも、よろしくね！", this.x[i] + 12, this.y[i] + 68 + 14 + 12);
 					if (this.c_fc <= 3) {
 						this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 68 + 28 + 2, 71, 0);
@@ -661,7 +670,7 @@ class KeyboardMenu {
 						);
 						this.hg.setColor(Color.yellow);
 						this.hg.drawString(this.item[i][0], this.x[i] + 12, this.y[i] + 64 + 12);
-						this.hg.setColor(Color.white);
+						this.hg.setColor(this.ap.mp.gamecolor_message_text);
 						this.hg.drawString("捕獲不可能", this.x[i] + 12, this.y[i] + 68 + 14 + 12);
 						if (this.c_fc <= 3) {
 							this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 68 + 28 + 2, 71, 0);
@@ -678,7 +687,7 @@ class KeyboardMenu {
 						);
 						this.hg.setColor(Color.yellow);
 						this.hg.drawString(this.item[i][0], this.x[i] + 12, this.y[i] + 64 + 12);
-						this.hg.setColor(Color.white);
+						this.hg.setColor(this.ap.mp.gamecolor_message_text);
 						this.hg.drawString("現在調査中", this.x[i] + 12, this.y[i] + 68 + 14 + 12);
 						if (this.c_fc <= 3) {
 							this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 68 + 28 + 2, 71, 0);
@@ -695,7 +704,7 @@ class KeyboardMenu {
 						);
 						this.hg.setColor(Color.yellow);
 						this.hg.drawString(this.item[i][0], this.x[i] + 12, this.y[i] + 64 + 12);
-						this.hg.setColor(Color.white);
+						this.hg.setColor(this.ap.mp.gamecolor_message_text);
 						this.hg.drawString("最大HP", this.x[i] + 12, this.y[i] + 68 + 14 + 12);
 						this.hg.drawString("" + this.item_int[i][0], this.x[i] + 56, this.y[i] + 68 + 28 + 12);
 						this.hg.drawString("最大PP", this.x[i] + 12, this.y[i] + 68 + 42 + 12);
@@ -729,16 +738,16 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 30 + this.item_kazu[i] * 14);
 					this.hg.setColor(Color.yellow);
 					this.hg.drawString("モンスターずかん", this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("見つけた数	" + this.item_int[i][0], this.x[i] + 6, this.y[i] + 6 + 18 + 0 + 12);
 					this.hg.drawString("捕まえた数	" + this.item_int[i][1], this.x[i] + 6, this.y[i] + 6 + 18 + 14 + 12);
 					break;
 				case 700:
 					// activeSerifutuki
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 30 + this.item_kazu[i] * 14 + 18);
-					this.hg.setColor(Color.cyan);
+					this.hg.setColor(this.ap.mp.gamecolor_message_name);
 					this.hg.drawString(this.item[i][15], this.x[i] + 24, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.message[i], this.x[i] + 24, this.y[i] + 6 + 12 + 18);
 					if (this.item_kazu[i] >= 1) {
 						for (let j = 0; j <= this.item_kazu[i] - 1; j++) {
@@ -758,13 +767,13 @@ class KeyboardMenu {
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 44);
 					this.hg.setColor(Color.yellow);
 					this.hg.drawString("おこづかい", this.x[i] + 6, this.y[i] + 6 + 12);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("" + this.item_int[i][0] + "円", this.x[i] + 6, this.y[i] + 6 + 18 + 12);
 					break;
 				case 900:
 					// activeKaimono
 					this.drawWindowbox(this.x[i], this.y[i], this.width[i], 30 + this.item_kazu[i] * 14);
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString(this.message[i], this.x[i] + 24, this.y[i] + 6 + 12);
 					if (this.item_kazu[i] >= 1) {
 						for (let j = 0; j <= this.item_kazu[i] - 1; j++) {
@@ -790,7 +799,7 @@ class KeyboardMenu {
 							this.gg.drawPT(this.x[i] + 12 + 8 + j * 40, this.y[i] + 12 + 8, this.item_int[i][j], 0);
 						}
 					}
-					this.hg.setColor(Color.white);
+					this.hg.setColor(this.ap.mp.gamecolor_message_text);
 					this.hg.drawString("みんな、元気になった。", this.x[i] + 12, this.y[i] + 64 + 12);
 					if (this.c_fc <= 3) {
 						this.gg.drawPT(this.x[i] + rightShiftIgnoreSign(this.width[i] - 14, 1), this.y[i] + 64 + 14 + 2, 71, 0);
@@ -802,9 +811,12 @@ class KeyboardMenu {
 	}
 
 	drawWindowbox(paramInt1: number, paramInt2: number, paramInt3: number, paramInt4: number) {
-		this.hg.setColor(Color.white);
-		this.hg.fillRect(paramInt1, paramInt2, paramInt3, paramInt4);
-		this.hg.setColor(Color.black);
+		this.hg.setColor(this.ap.mp.gamecolor_message_border);
+		this.hg.fillRect(paramInt1, paramInt2, paramInt3, 2);
+		this.hg.fillRect(paramInt1, paramInt2 + 2, 2, paramInt4 - 4);
+		this.hg.fillRect(paramInt1 + paramInt3 - 2, paramInt2 + 2, 2, paramInt4 - 4);
+		this.hg.fillRect(paramInt1, paramInt2 + paramInt4 - 2, paramInt3, 2);
+		this.hg.setColor(this.ap.mp.gamecolor_message_back);
 		this.hg.fillRect(paramInt1 + 2, paramInt2 + 2, paramInt3 - 4, paramInt4 - 4);
 	}
 }

--- a/Sources/MainProgram.ts
+++ b/Sources/MainProgram.ts
@@ -3792,7 +3792,6 @@ class MainProgram {
 			case 91:
 				this.ml_mode_c++;
 				if (this.ml_mode_c > this.mode_wait_stagestart) this.ml_mode = 100;
-				drawStageStart(); // 2.8では呼び出されていなかったのでもしかしたら不要？
 				returningTitle();
 				break;
 

--- a/Sources/MainProgram.ts
+++ b/Sources/MainProgram.ts
@@ -56,6 +56,13 @@ class MainProgram {
 	gamecolor_firebar2: Color;
 	gamecolor_mizunohadou: Color;
 	gamecolor_kaishi: Color;
+	gamecolor_message_back: Color;
+	gamecolor_message_border: Color;
+	gamecolor_message_name: Color;
+	gamecolor_message_text: Color;
+	gamecolor_gauge_border: Color;
+	gamecolor_gauge_back1: Color;
+	gamecolor_gauge_back2: Color;
 	ana_kazu: number;
 	ochiru_y: number;
 	j_hashiru_f: boolean;
@@ -370,6 +377,13 @@ class MainProgram {
 		this.gamecolor_firebar2 = undefined!;
 		this.gamecolor_mizunohadou = undefined!;
 		this.gamecolor_kaishi = undefined!;
+		this.gamecolor_message_back = undefined!;
+		this.gamecolor_message_border = undefined!;
+		this.gamecolor_message_name = undefined!;
+		this.gamecolor_message_text = undefined!;
+		this.gamecolor_gauge_border = undefined!;
+		this.gamecolor_gauge_back1 = undefined!;
+		this.gamecolor_gauge_back2 = undefined!;
 		this.ana_kazu = undefined!;
 		this.ochiru_y = undefined!;
 		this.j_hashiru_f = undefined!;
@@ -4082,11 +4096,11 @@ class MainProgram {
 				concatString("gamecolor_back", stage)
 			);
 		});
-		(["kaishi", "mizunohadou"] as const).forEach((name) => {
+		(["kaishi", "mizunohadou", "message_back", "message_border", "message_name", "message_text", "gauge_border"] as const).forEach((name) => {
 			setColorParam(`${name}_red`, `${name}_green`, `${name}_blue`, concatString("gamecolor_", name));
 		});
 		setColorParam("scorecolor_red", "scorecolor_green", "scorecolor_blue", "gamecolor_score");
-		(["grenade", "firebar"] as const).forEach((name) => {
+		(["grenade", "firebar", "gauge_back"] as const).forEach((name) => {
 			([1, 2] as const).forEach((i) => {
 				setColorParam(`${name}_red${i}`, `${name}_green${i}`, `${name}_blue${i}`, concatString("gamecolor_", name, i));
 			});
@@ -17080,7 +17094,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 									224,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.km.move();
 								this.km.mode = 400;
@@ -17347,7 +17361,7 @@ class MainProgram {
 										rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 										rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 										272,
-										Color.cyan
+										this.gamecolor_message_name
 									);
 									this.km.mode = 200;
 								} else {
@@ -17359,7 +17373,7 @@ class MainProgram {
 										rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 										rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 										272,
-										Color.cyan
+										this.gamecolor_message_name
 									);
 									this.km.mode = 250;
 								}
@@ -17457,7 +17471,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 									272,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.km.mode = 250;
 							}
@@ -17500,7 +17514,7 @@ class MainProgram {
 										rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 										rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 										272,
-										Color.cyan
+										this.gamecolor_message_name
 									);
 									this.km.mode = 300;
 								} else {
@@ -17512,7 +17526,7 @@ class MainProgram {
 										rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 										rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 										272,
-										Color.cyan
+										this.gamecolor_message_name
 									);
 									this.km.mode = 350;
 								}
@@ -17610,7 +17624,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 									272,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.km.mode = 350;
 							}
@@ -17652,7 +17666,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 									272,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.km.mode = 200;
 								this.km.move();
@@ -23151,7 +23165,7 @@ class MainProgram {
 								rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 								rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 								272,
-								Color.cyan
+								this.gamecolor_message_name
 							);
 							this.km.mode = 200;
 						} else {
@@ -23163,7 +23177,7 @@ class MainProgram {
 								rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 								rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 								252,
-								Color.cyan
+								this.gamecolor_message_name
 							);
 							this.km.mode = 250;
 						}
@@ -23236,7 +23250,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40 - 160,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16 + 46,
 									252,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.dkey_count[0] -= l2;
 								this.gs.rsAddSound(13);
@@ -23314,7 +23328,7 @@ class MainProgram {
 								rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 								rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 								272,
-								Color.cyan
+								this.gamecolor_message_name
 							);
 							this.km.mode = 200;
 						} else {
@@ -23326,7 +23340,7 @@ class MainProgram {
 								rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 								rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 								252,
-								Color.cyan
+								this.gamecolor_message_name
 							);
 							this.km.mode = 250;
 						}
@@ -23399,7 +23413,7 @@ class MainProgram {
 									rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40 - 160,
 									rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16 + 46,
 									252,
-									Color.cyan
+									this.gamecolor_message_name
 								);
 								this.dkey_count[1] -= i3;
 								this.gs.rsAddSound(13);
@@ -23514,7 +23528,7 @@ class MainProgram {
 								rounddown(this.gg.di.width * 0.625 - 224 / 2) - 40,
 								rounddown(this.gg.di.height * 0.2875 - (30 + 3 * 14) / 2) - 16,
 								272,
-								Color.cyan
+								this.gamecolor_message_name
 							);
 							this.km.mode = 200;
 							this.km.move();

--- a/Sources/MasaoJSS.ts
+++ b/Sources/MasaoJSS.ts
@@ -3735,6 +3735,14 @@ class MasaoJSS {
 			} else return false;
 		};
 
+		/**
+		 * Canvas正男本体のバージョン情報を取得します。
+		 * 得られる値はCanvasMasao.versionで得られる値と同じです。
+		 *
+		 * @returns {string} バージョン情報
+		 * 
+		 * @since canvas正男
+		 */
 		this.getVersion = () => {
 			return <string>process.env.MC_CANVAS_VER;
 		};

--- a/Sources/MasaoJSS.ts
+++ b/Sources/MasaoJSS.ts
@@ -3873,7 +3873,7 @@ class MasaoJSS {
 						return true;
 						break;
 
-					case 18: // ゲージの背景色1
+					case 18: // ゲージの背景色2
 						mc.mp.gamecolor_gauge_back2 = new Color(_r, _g, _b, _a);
 						return true;
 						break;

--- a/Sources/MasaoJSS.ts
+++ b/Sources/MasaoJSS.ts
@@ -3199,7 +3199,7 @@ class MasaoJSS {
 		 * @param {number} x X座標
 		 * @param {number} y Y座標
 		 * @param {number} code パターンコード
-		 * @param {Numbeer} dir 向き
+		 * @param {number} dir 向き
 		 */
 		this.drawPattern = function (s, s1, s2, s3) {
 			var j = 0;

--- a/Sources/MasaoJSS.ts
+++ b/Sources/MasaoJSS.ts
@@ -244,6 +244,7 @@ class MasaoJSS {
 	getPartsDefinition: (code: string | number) => Parts | null;
 	setItem: (x?: string | number, y?: string | number, type?: string | number) => boolean;
 	getVersion: () => string;
+	setSystemColor: (type: string | number, r: string | number, g: string | number, b: string | number, a: string | number) => boolean;
 
 	constructor(mc: MasaoConstruction, caseInsensitive: boolean) {
 		this.my_offscreen_img = null;
@@ -3745,6 +3746,141 @@ class MasaoJSS {
 		 */
 		this.getVersion = () => {
 			return <string>process.env.MC_CANVAS_VER;
+		};
+
+		/**
+		 * システムで使用する色を変更します。
+		 * 
+		 * 色の名前はパラメータ名から色名を除外したものに準じます。
+		 *
+		 * @param {number} type 変更する色の名前
+		 * @param {number} r R成分
+		 * @param {number} g G成分
+		 * @param {number} b B成分
+		 * @param {number} alpha 不透明度
+		 * 
+		 * @since canvas正男
+		 */
+		this.setSystemColor = function (type = 0, r = 0, g = 0, b = 0, a = 255) {
+			if (mc.mp) {
+				let _r = parseInt(r as string);
+				let _g = parseInt(g as string);
+				let _b = parseInt(b as string);
+				let _a = parseInt(a as string);
+				let _type = parseInt(type as string);
+				if (isNaN(_r) || isNaN(_g) || isNaN(_b) || isNaN(_a)) _type = 0;
+				if (_type <= 0) return false;
+
+				const checkValidNumber = (n: number) => {
+					let result: number = n;
+					if (result < 0) result = 0;
+					if (result > 255) result = 255;
+					return result;
+				};
+
+				_r = checkValidNumber(_r);
+				_g = checkValidNumber(_g);
+				_b = checkValidNumber(_b);
+				_a = checkValidNumber(_a);
+
+				switch (_type) {
+					default:
+						return false;
+						break;
+
+					case 1: // ステージ1のゲーム画面の背景色
+						mc.mp.gamecolor_back = new Color(_r, _g, _b);
+						return true;
+						break;
+
+					case 2: // ステージ2のゲーム画面の背景色
+						mc.mp.gamecolor_back_s = new Color(_r, _g, _b);
+						return true;
+						break;
+
+					case 3: // ステージ3のゲーム画面の背景色
+						mc.mp.gamecolor_back_t = new Color(_r, _g, _b);
+						return true;
+						break;
+
+					case 4: // ステージ4のゲーム画面の背景色
+						mc.mp.gamecolor_back_f = new Color(_r, _g, _b);
+						return true;
+						break;
+
+					case 5: // ステージ番号表示画面の背景色
+						mc.mp.gamecolor_kaishi = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 6: // スコアなどの文字の色
+						mc.mp.gamecolor_score = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 7: // グレネードの爆発などの色1
+						mc.mp.gamecolor_grenade1 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 8: // グレネードの爆発などの色2
+						mc.mp.gamecolor_grenade2 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 9: // 水の波動などの色
+						mc.mp.gamecolor_mizunohadou = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 10: // ファイヤーバーなどの色1
+						mc.mp.gamecolor_firebar1 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 11: // ファイヤーバーなどの色2
+						mc.mp.gamecolor_firebar2 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 12: // メッセージウィンドウの背景色
+						mc.mp.gamecolor_message_back = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 13: // メッセージウィンドウの枠色
+						mc.mp.gamecolor_message_border = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 14: // メッセージウィンドウの名前の文字色
+						mc.mp.gamecolor_message_name = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 15: // メッセージウィンドウの文字色
+						mc.mp.gamecolor_message_text = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 16: // ゲージの枠の色
+						mc.mp.gamecolor_gauge_border = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 17: // ゲージの背景色1
+						mc.mp.gamecolor_gauge_back1 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+
+					case 18: // ゲージの背景色1
+						mc.mp.gamecolor_gauge_back2 = new Color(_r, _g, _b, _a);
+						return true;
+						break;
+				}
+			} else {
+				return false;
+			}
 		};
 
 		/**

--- a/Sources/MasaoParameters.ts
+++ b/Sources/MasaoParameters.ts
@@ -327,6 +327,27 @@ export function makeKnownDefaultParameters() {
 		font_score: "Helvetica,Arial,ＭＳ ゴシック,HG ゴシックB Sun,HG ゴシックB,monospace",
 		font_message: "Helvetica,Arial,ＭＳ ゴシック,HG ゴシックB Sun,HG ゴシックB,monospace",
 		mcs_screen_size: "2",
+		message_back_red: "0",
+		message_back_green: "0",
+		message_back_blue: "0",
+		message_border_red: "255",
+		message_border_green: "255",
+		message_border_blue: "255",
+		message_name_red: "0",
+		message_name_green: "255",
+		message_name_blue: "255",
+		message_text_red: "255",
+		message_text_green: "255",
+		message_text_blue: "255",
+		gauge_border_red: "255",
+		gauge_border_green: "255",
+		gauge_border_blue: "255",
+		gauge_back_red1: "255",
+		gauge_back_green1: "255",
+		gauge_back_blue1: "0",
+		gauge_back_red2: "255",
+		gauge_back_green2: "0",
+		gauge_back_blue2: "0"
 	};
 }
 

--- a/Sources/drawGamescreenJSS.ts
+++ b/Sources/drawGamescreenJSS.ts
@@ -958,7 +958,7 @@ export const drawM = function (this: MainProgram) {
 					this.gamecolor_mizunohadou.getRed(),
 					this.gamecolor_mizunohadou.getGreen(),
 					this.gamecolor_mizunohadou.getBlue(),
-					176
+					this.gamecolor_mizunohadou.getAlpha() === 255 ? 176 : this.gamecolor_mizunohadou.getAlpha()
 				)
 			);
 			const radius = characterobject.c2;
@@ -1561,11 +1561,11 @@ export const drawHPGauge = function (this: MainProgram) {
 	this.hg.setFont(new Font(Font.DIALOG, 1, 16));
 	this.hg.setColor(this.gamecolor_score);
 	this.hg.drawString(this.gauge_text, x, y - 6);
-	this.hg.setColor(Color.red);
-	this.hg.fillRect(x, y, 200, 8);
-	this.hg.setColor(Color.yellow);
+	this.hg.setColor(this.gamecolor_gauge_back2);
+	this.hg.fillRect(x + this.gauge_value, y, 200 - this.gauge_value, 8);
+	this.hg.setColor(this.gamecolor_gauge_back1);
 	this.hg.fillRect(x, y, this.gauge_value, 8);
-	this.hg.setColor(Color.white);
+	this.hg.setColor(this.gamecolor_gauge_border);
 	this.hg.fillRect(x - 1, y - 1, 202, 1);
 	this.hg.fillRect(x - 1, y, 1, 8);
 	this.hg.fillRect(x + 200, y, 1, 8);
@@ -1638,13 +1638,13 @@ export const drawHitokotoMessage = function (this: MainProgram) {
 	const beforeFont = this.hg._font;
 	this.hg.setFont(new Font(this.gg.font_message, 0, 12));
 	// 名前を描画
-	this.hg.setColor(Color.cyan);
+	this.hg.setColor(this.gamecolor_message_name);
 	const param_name = `hitokoto${this.hitokoto_num}_name`;
 	const name = this.hitokoto_num === 5 ? this.showm_data[0]! : this.tdb.getValue(param_name)!;
 	this.hg.drawString(name, box_x + 6, box_y + 6 + 12);
 
 	// メッセージ本文を描画
-	this.hg.setColor(Color.white);
+	this.hg.setColor(this.gamecolor_message_text);
 	for (const [i, message] of messages.entries()) {
 		const dy = 18 + i * 14 + 12;
 		this.hg.drawString(message, box_x + 6, box_y + 6 + dy);


### PR DESCRIPTION
## 色変更可能箇所を追加
メッセージの枠、背景、文字の色やゲージの枠の色などを変更可能にしました。
カイオールの水の波動 直進はアルファ値が設定されていない場合デフォルトのアルファ値を参照するようにしました。
メッセージの枠は背景に重ならないようにしました。

## setSystemColorメソッドを追加
上記の色含むシステムの色を変更するsetSystemColorメソッドを追加しました。
MasaoJSSからはアルファ値の変更もできるようになっています。
ステージの背景色にはアルファ値を設定しても無視されるようになっています。